### PR TITLE
feat: add rules engine crate and integrate with timeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/logline/logline"
 
 [workspace]
-members = ["logline-core", "logline-protocol", "logline-id", "logline-timeline"]
+members = ["logline-core", "logline-protocol", "logline-id", "logline-timeline", "logline-rules"]
 [dependencies]
 # Principais dependências
 serde = { version = "1.0", features = ["derive"] }

--- a/Roadmap_and_tasklist_Universe_LogLine.md
+++ b/Roadmap_and_tasklist_Universe_LogLine.md
@@ -62,12 +62,12 @@ With identity and protocol in place:
 
 The rules system would be separate but closely integrated with the protocol:
 
-\- Grammar parsing and validation  
-\- Rule execution environment  
-\- Context management  
-\- Rule storage and versioning  
-\- Rule chaining and dependencies  
-\- Multi-tenant rule isolation
+- [x] Grammar parsing and validation (YAML/JSON loader with structural checks)
+- [x] Rule execution environment
+- [ ] Context management
+- [ ] Rule storage and versioning
+- [ ] Rule chaining and dependencies
+- [ ] Multi-tenant rule isolation
 
 \#\#\# 6\. Create Core Engine (\`logline-engine\`)
 

--- a/logline-rules/Cargo.toml
+++ b/logline-rules/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "logline-rules"
+version = "0.1.0"
+edition = "2021"
+description = "Rules engine and enforcement primitives for the LogLine ecosystem"
+license = "MIT"
+authors = ["LogLine Team"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.9"
+thiserror = "1.0"
+logline-protocol = { path = "../logline-protocol" }
+tracing = "0.1"

--- a/logline-rules/src/action.rs
+++ b/logline-rules/src/action.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Declarative actions that may be triggered when a rule matches a span.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RuleAction {
+    /// Explicitly allow processing to continue.
+    Allow,
+    /// Reject the span and return the provided reason to the caller.
+    Reject { reason: String },
+    /// Simulate-only execution. The optional note is recorded in the evaluation outcome.
+    Simulate { note: Option<String> },
+    /// Append a tag to the span.
+    AddTag { tag: String },
+    /// Attach or override a metadata entry on the span.
+    SetMetadata { key: String, value: Value },
+    /// Mark the span as processed to avoid re-processing in downstream systems.
+    MarkProcessed,
+    /// Append a diagnostic note to the evaluation outcome.
+    Note { message: String },
+}

--- a/logline-rules/src/condition.rs
+++ b/logline-rules/src/condition.rs
@@ -1,0 +1,153 @@
+use logline_protocol::timeline::Span;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// JSON pointer-like field path used to inspect attributes on a [`Span`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct FieldPath(String);
+
+impl FieldPath {
+    pub fn new(path: impl Into<String>) -> Self {
+        Self(path.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn segments(&self) -> impl Iterator<Item = &str> {
+        self.0.split('.').filter(|segment| !segment.is_empty())
+    }
+
+    fn locate<'a>(&self, root: &'a Value) -> Option<&'a Value> {
+        let mut current = root;
+        for segment in self.segments() {
+            match current {
+                Value::Object(map) => match map.get(segment) {
+                    Some(value) => current = value,
+                    None => return None,
+                },
+                Value::Array(items) => {
+                    let index: usize = segment.parse().ok()?;
+                    current = items.get(index)?;
+                }
+                _ => return None,
+            }
+        }
+        Some(current)
+    }
+}
+
+impl From<&str> for FieldPath {
+    fn from(value: &str) -> Self {
+        FieldPath::new(value)
+    }
+}
+
+impl From<String> for FieldPath {
+    fn from(value: String) -> Self {
+        FieldPath::new(value)
+    }
+}
+
+/// Conditional expression that determines when a rule should trigger.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RuleCondition {
+    /// Matches all spans.
+    Always,
+    /// All nested conditions must return true.
+    All { conditions: Vec<RuleCondition> },
+    /// Any of the nested conditions must return true.
+    Any { conditions: Vec<RuleCondition> },
+    /// Negate the outcome of the nested condition.
+    Not { condition: Box<RuleCondition> },
+    /// Compare the value at `field` for equality.
+    Equals { field: FieldPath, value: Value },
+    /// Compare the value at `field` for inequality.
+    NotEquals { field: FieldPath, value: Value },
+    /// Ensure the field exists within the serialized span.
+    Exists { field: FieldPath },
+    /// Ensure the field is missing from the serialized span.
+    Missing { field: FieldPath },
+    /// Check if the given field contains a textual snippet.
+    ContainsText { field: FieldPath, text: String },
+    /// Whether the span already has the provided tag.
+    ContainsTag { tag: String },
+    /// Whether the numerical value at `field` is greater than the provided value.
+    GreaterThan { field: FieldPath, value: f64 },
+    /// Whether the numerical value at `field` is less than the provided value.
+    LessThan { field: FieldPath, value: f64 },
+}
+
+impl RuleCondition {
+    pub fn always() -> Self {
+        RuleCondition::Always
+    }
+
+    pub fn evaluate(&self, span: &Span, snapshot: &Value) -> bool {
+        match self {
+            RuleCondition::Always => true,
+            RuleCondition::All { conditions } => conditions
+                .iter()
+                .all(|condition| condition.evaluate(span, snapshot)),
+            RuleCondition::Any { conditions } => conditions
+                .iter()
+                .any(|condition| condition.evaluate(span, snapshot)),
+            RuleCondition::Not { condition } => !condition.evaluate(span, snapshot),
+            RuleCondition::Equals { field, value } => field
+                .locate(snapshot)
+                .map(|actual| values_equal(actual, value))
+                .unwrap_or(false),
+            RuleCondition::NotEquals { field, value } => !field
+                .locate(snapshot)
+                .map(|actual| values_equal(actual, value))
+                .unwrap_or(false),
+            RuleCondition::Exists { field } => field.locate(snapshot).is_some(),
+            RuleCondition::Missing { field } => field.locate(snapshot).is_none(),
+            RuleCondition::ContainsText { field, text } => field
+                .locate(snapshot)
+                .and_then(|value| value.as_str())
+                .map(|candidate| candidate.contains(text))
+                .unwrap_or(false),
+            RuleCondition::ContainsTag { tag } => span.tags.iter().any(|existing| existing == tag),
+            RuleCondition::GreaterThan { field, value } => field
+                .locate(snapshot)
+                .and_then(Value::as_f64)
+                .map(|candidate| candidate > *value)
+                .unwrap_or(false),
+            RuleCondition::LessThan { field, value } => field
+                .locate(snapshot)
+                .and_then(Value::as_f64)
+                .map(|candidate| candidate < *value)
+                .unwrap_or(false),
+        }
+    }
+}
+
+fn values_equal(left: &Value, right: &Value) -> bool {
+    match (left, right) {
+        (Value::Number(lhs), Value::Number(rhs)) => match (lhs.as_f64(), rhs.as_f64()) {
+            (Some(l), Some(r)) => (l - r).abs() < f64::EPSILON,
+            _ => lhs == rhs,
+        },
+        _ => left == right,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn resolves_nested_fields() {
+        let path = FieldPath::from("metadata.author.name");
+        let value = json!({
+            "metadata": {"author": {"name": "Ada"}}
+        });
+
+        assert_eq!(path.locate(&value).and_then(Value::as_str), Some("Ada"));
+    }
+}

--- a/logline-rules/src/engine.rs
+++ b/logline-rules/src/engine.rs
@@ -1,0 +1,166 @@
+use logline_protocol::timeline::Span;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::action::RuleAction;
+use crate::condition::RuleCondition;
+use crate::error::RuleError;
+use crate::loader::load_rules;
+use crate::outcome::{Decision, EnforcementOutcome};
+use crate::rule::Rule;
+
+/// Runtime executor that evaluates spans against a set of rules.
+#[derive(Debug, Default, Clone)]
+pub struct RuleEngine {
+    rules: Vec<Rule>,
+}
+
+impl RuleEngine {
+    /// Construct an engine from the provided rules, sorting them by priority.
+    pub fn new(mut rules: Vec<Rule>) -> Self {
+        rules.sort_by(|a, b| a.priority.cmp(&b.priority).then(a.id.cmp(&b.id)));
+        Self { rules }
+    }
+
+    /// Loads rules from the given path (file or directory).
+    pub fn from_path(path: impl AsRef<std::path::Path>) -> Result<Self, RuleError> {
+        let rules = load_rules(path)?;
+        Ok(Self::new(rules))
+    }
+
+    /// Borrow the underlying rule set.
+    pub fn rules(&self) -> &[Rule] {
+        &self.rules
+    }
+
+    /// Whether the engine contains no rules.
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// Evaluate a span and mutate it according to any triggered actions.
+    pub fn apply(&self, span: &mut Span) -> EnforcementOutcome {
+        let mut outcome = EnforcementOutcome::new();
+
+        for rule in &self.rules {
+            if !rule.is_enabled() {
+                continue;
+            }
+
+            let snapshot = serde_json::to_value(&span).unwrap_or(Value::Null);
+            if !rule.condition.evaluate(span, &snapshot) {
+                continue;
+            }
+
+            debug!(rule_id = %rule.id, "rule matched span");
+            outcome.record_rule(rule.id.clone());
+            if let Some(description) = &rule.description {
+                outcome.push_note(description.clone());
+            }
+
+            for action in &rule.actions {
+                apply_action(span, action, &mut outcome);
+                if outcome.is_reject() {
+                    debug!(rule_id = %rule.id, "rule rejected span");
+                    return outcome;
+                }
+            }
+        }
+
+        outcome
+    }
+
+    /// Evaluate a span without mutating it, returning the outcome.
+    pub fn evaluate(&self, span: &Span) -> EnforcementOutcome {
+        let mut clone = span.clone();
+        self.apply(&mut clone)
+    }
+}
+
+fn apply_action(span: &mut Span, action: &RuleAction, outcome: &mut EnforcementOutcome) {
+    match action {
+        RuleAction::Allow => outcome.update_decision(Decision::Allow),
+        RuleAction::Reject { reason } => {
+            outcome.update_decision(Decision::Reject {
+                reason: reason.clone(),
+            });
+        }
+        RuleAction::Simulate { note } => {
+            outcome.update_decision(Decision::Simulate { note: note.clone() });
+            if let Some(note) = note {
+                outcome.push_note(note.clone());
+            }
+        }
+        RuleAction::AddTag { tag } => {
+            span.add_tag(tag.clone());
+            outcome.push_tag(tag.clone());
+        }
+        RuleAction::SetMetadata { key, value } => {
+            span.add_metadata(key.clone(), value.clone());
+            outcome.push_metadata(key.clone(), value.clone());
+        }
+        RuleAction::MarkProcessed => {
+            span.mark_processed();
+        }
+        RuleAction::Note { message } => {
+            outcome.push_note(message.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use logline_protocol::timeline::{SpanBuilder, SpanStatus};
+    use serde_json::json;
+
+    fn build_span() -> Span {
+        SpanBuilder::new("node", "example span")
+            .status(SpanStatus::Executed)
+            .build()
+    }
+
+    #[test]
+    fn applies_matching_rule() {
+        let rule = Rule {
+            id: "allow".into(),
+            description: Some("allow processed spans".into()),
+            priority: 10,
+            enabled: true,
+            labels: vec![],
+            condition: RuleCondition::Always,
+            actions: vec![RuleAction::MarkProcessed],
+        };
+        let engine = RuleEngine::new(vec![rule]);
+        let mut span = build_span();
+
+        let outcome = engine.apply(&mut span);
+        assert!(span.processed);
+        assert_eq!(outcome.applied_rules, vec!["allow".to_string()]);
+    }
+
+    #[test]
+    fn rejects_span_when_condition_matches() {
+        let rule = Rule {
+            id: "deny".into(),
+            description: None,
+            priority: 1,
+            enabled: true,
+            labels: vec![],
+            condition: RuleCondition::Equals {
+                field: "title".into(),
+                value: json!("example span"),
+            },
+            actions: vec![RuleAction::Reject {
+                reason: "blocked by rule".into(),
+            }],
+        };
+
+        let engine = RuleEngine::new(vec![rule]);
+        let mut span = build_span();
+        let outcome = engine.apply(&mut span);
+
+        assert!(matches!(outcome.decision, Decision::Reject { .. }));
+        assert!(outcome.is_reject());
+    }
+}

--- a/logline-rules/src/error.rs
+++ b/logline-rules/src/error.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Errors returned by the rules engine when loading or evaluating rule sets.
+#[derive(Debug, Error)]
+pub enum RuleError {
+    #[error("rules path does not exist: {0}")]
+    MissingPath(String),
+    #[error("failed to read rules from {path}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse rules from {path}: {message}")]
+    Parse { path: String, message: String },
+    #[error("duplicate rule identifier detected: {id}")]
+    DuplicateRule { id: String },
+}
+
+impl RuleError {
+    pub fn from_io(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        RuleError::Io {
+            path: path.into().display().to_string(),
+            source,
+        }
+    }
+
+    pub fn parse_error(path: impl Into<PathBuf>, message: impl Into<String>) -> Self {
+        RuleError::Parse {
+            path: path.into().display().to_string(),
+            message: message.into(),
+        }
+    }
+}

--- a/logline-rules/src/lib.rs
+++ b/logline-rules/src/lib.rs
@@ -1,0 +1,53 @@
+//! Rule evaluation engine for the LogLine ecosystem.
+//!
+//! This crate exposes a declarative rule system used by services such as the
+//! timeline microservice to enforce policies before spans are persisted. Rules
+//! are expressed as YAML/JSON documents that define matching conditions and
+//! actions to perform when a span satisfies those conditions.
+
+mod action;
+mod condition;
+mod engine;
+mod error;
+mod loader;
+mod outcome;
+mod rule;
+
+pub use action::RuleAction;
+pub use condition::{FieldPath, RuleCondition};
+pub use engine::RuleEngine;
+pub use error::RuleError;
+pub use outcome::{Decision, EnforcementOutcome};
+pub use rule::Rule;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use logline_protocol::timeline::SpanBuilder;
+    use serde_json::json;
+
+    #[test]
+    fn evaluates_simple_rule() {
+        let rule = Rule {
+            id: "allow".into(),
+            description: None,
+            priority: 1,
+            enabled: true,
+            labels: vec![],
+            condition: RuleCondition::Equals {
+                field: FieldPath::from("title"),
+                value: json!("demo"),
+            },
+            actions: vec![RuleAction::AddTag {
+                tag: "matched".into(),
+            }],
+        };
+
+        let engine = RuleEngine::new(vec![rule]);
+        let mut span = SpanBuilder::new("node", "demo").build();
+        let outcome = engine.apply(&mut span);
+
+        assert_eq!(outcome.applied_rules, vec!["allow".to_string()]);
+        assert!(span.tags.iter().any(|tag| tag == "matched"));
+    }
+}

--- a/logline-rules/src/loader.rs
+++ b/logline-rules/src/loader.rs
@@ -1,0 +1,95 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::error::RuleError;
+use crate::rule::Rule;
+
+pub fn load_rules(path: impl AsRef<Path>) -> Result<Vec<Rule>, RuleError> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Err(RuleError::MissingPath(path.display().to_string()));
+    }
+
+    let mut rules = if path.is_dir() {
+        load_from_directory(path)?
+    } else {
+        load_from_file(path)?
+    };
+
+    deduplicate(&mut rules)?;
+    rules.sort_by(|a, b| a.priority.cmp(&b.priority).then(a.id.cmp(&b.id)));
+
+    Ok(rules)
+}
+
+fn load_from_directory(path: &Path) -> Result<Vec<Rule>, RuleError> {
+    let mut rules = Vec::new();
+    for entry in fs::read_dir(path).map_err(|err| RuleError::from_io(path, err))? {
+        let entry = entry.map_err(|err| RuleError::from_io(path, err))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|err| RuleError::from_io(entry.path(), err))?;
+        if file_type.is_dir() {
+            continue;
+        }
+
+        if let Some(ext) = entry.path().extension().and_then(|value| value.to_str()) {
+            if matches!(ext, "json" | "yaml" | "yml") {
+                let mut file_rules = load_from_file(&entry.path())?;
+                rules.append(&mut file_rules);
+            }
+        }
+    }
+
+    Ok(rules)
+}
+
+fn load_from_file(path: &Path) -> Result<Vec<Rule>, RuleError> {
+    let raw = fs::read_to_string(path).map_err(|err| RuleError::from_io(path, err))?;
+    parse_rules(&raw, path)
+}
+
+fn parse_rules(raw: &str, path: &Path) -> Result<Vec<Rule>, RuleError> {
+    let mut attempts = Vec::new();
+
+    if let Ok(doc) = serde_yaml::from_str::<RuleDocument>(raw) {
+        return Ok(doc.rules);
+    }
+
+    attempts.push("rules document".to_string());
+
+    if let Ok(list) = serde_yaml::from_str::<Vec<Rule>>(raw) {
+        return Ok(list);
+    }
+
+    attempts.push("list".to_string());
+
+    if let Ok(rule) = serde_yaml::from_str::<Rule>(raw) {
+        return Ok(vec![rule]);
+    }
+
+    attempts.push("single".to_string());
+
+    let message = format!("unable to parse rules file using {:?} formats", attempts);
+    Err(RuleError::parse_error(path.to_path_buf(), message))
+}
+
+fn deduplicate(rules: &mut [Rule]) -> Result<(), RuleError> {
+    let mut seen = HashSet::new();
+    for rule in rules.iter() {
+        if !seen.insert(rule.id.clone()) {
+            return Err(RuleError::DuplicateRule {
+                id: rule.id.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct RuleDocument {
+    rules: Vec<Rule>,
+}

--- a/logline-rules/src/outcome.rs
+++ b/logline-rules/src/outcome.rs
@@ -1,0 +1,97 @@
+use serde_json::Value;
+
+/// Final decision from applying all matched rules.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decision {
+    Allow,
+    Reject { reason: String },
+    Simulate { note: Option<String> },
+}
+
+impl Decision {
+    pub fn merge(self, other: Decision) -> Decision {
+        use Decision::*;
+        match (self, other) {
+            (Reject { .. }, Reject { reason }) => Reject { reason },
+            (Reject { reason }, _) => Reject { reason },
+            (_, Reject { reason }) => Reject { reason },
+            (Simulate { note }, Simulate { note: other }) => Simulate {
+                note: other.or(note),
+            },
+            (Simulate { note }, Allow) => Simulate { note },
+            (Allow, Simulate { note }) => Simulate { note },
+            (Allow, Allow) => Allow,
+        }
+    }
+}
+
+impl Default for Decision {
+    fn default() -> Self {
+        Decision::Allow
+    }
+}
+
+/// Aggregated view of how rules affected the span.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EnforcementOutcome {
+    pub decision: Decision,
+    pub applied_rules: Vec<String>,
+    pub added_tags: Vec<String>,
+    pub metadata_updates: Vec<(String, Value)>,
+    pub notes: Vec<String>,
+}
+
+impl EnforcementOutcome {
+    pub fn new() -> Self {
+        Self {
+            decision: Decision::Allow,
+            applied_rules: Vec::new(),
+            added_tags: Vec::new(),
+            metadata_updates: Vec::new(),
+            notes: Vec::new(),
+        }
+    }
+
+    pub fn record_rule(&mut self, id: impl Into<String>) {
+        self.applied_rules.push(id.into());
+    }
+
+    pub fn push_tag(&mut self, tag: impl Into<String>) {
+        let tag = tag.into();
+        if !self.added_tags.contains(&tag) {
+            self.added_tags.push(tag);
+        }
+    }
+
+    pub fn push_metadata(&mut self, key: impl Into<String>, value: Value) {
+        let key = key.into();
+        if let Some(existing) = self
+            .metadata_updates
+            .iter_mut()
+            .find(|(existing_key, _)| existing_key == &key)
+        {
+            existing.1 = value;
+        } else {
+            self.metadata_updates.push((key, value));
+        }
+    }
+
+    pub fn push_note(&mut self, note: impl Into<String>) {
+        self.notes.push(note.into());
+    }
+
+    pub fn update_decision(&mut self, new_decision: Decision) {
+        let current = std::mem::take(&mut self.decision);
+        self.decision = current.merge(new_decision);
+    }
+
+    pub fn is_reject(&self) -> bool {
+        matches!(self.decision, Decision::Reject { .. })
+    }
+}
+
+impl Default for EnforcementOutcome {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/logline-rules/src/rule.rs
+++ b/logline-rules/src/rule.rs
@@ -1,0 +1,42 @@
+use crate::action::RuleAction;
+use crate::condition::RuleCondition;
+use serde::{Deserialize, Serialize};
+
+/// Declarative rule definition applied to spans on the timeline.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Rule {
+    /// Unique identifier for the rule. Used for reporting and deduplication.
+    pub id: String,
+    /// Optional human readable description.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Ordering priority. Lower numbers are evaluated first.
+    #[serde(default = "Rule::default_priority")]
+    pub priority: u32,
+    /// Whether the rule is active.
+    #[serde(default = "Rule::default_enabled")]
+    pub enabled: bool,
+    /// Additional labels for reporting / filtering.
+    #[serde(default)]
+    pub labels: Vec<String>,
+    /// Matching condition for the rule.
+    #[serde(default = "RuleCondition::always")]
+    pub condition: RuleCondition,
+    /// Actions executed when the condition matches.
+    #[serde(default)]
+    pub actions: Vec<RuleAction>,
+}
+
+impl Rule {
+    pub fn default_priority() -> u32 {
+        100
+    }
+
+    pub fn default_enabled() -> bool {
+        true
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+}

--- a/logline-timeline/Cargo.toml
+++ b/logline-timeline/Cargo.toml
@@ -19,6 +19,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 logline-core = { path = "../logline-core" }
 logline-protocol = { path = "../logline-protocol" }
+logline-rules = { path = "../logline-rules" }
 sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio", "postgres", "uuid", "chrono", "json", "macros", "migrate"] }
 hyper = "1.4"
 

--- a/logline-timeline/src/main.rs
+++ b/logline-timeline/src/main.rs
@@ -1,6 +1,7 @@
 mod repository;
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Path, Query, State};
@@ -17,11 +18,12 @@ use logline_core::logging;
 use logline_protocol::timeline::{
     Span, SpanStatus, SpanType, TimelineEntry, TimelineQuery, Visibility,
 };
+use logline_rules::{Decision, RuleEngine, RuleError};
 use repository::TimelineRepository;
 use serde::Deserialize;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 #[tokio::main]
@@ -38,11 +40,13 @@ async fn main() -> Result<(), ServerError> {
         .parse()?;
 
     let repository = TimelineRepository::from_config(&config).await?;
+    let rule_engine = load_rule_engine_from_env()?;
     let (tx, _rx) = broadcast::channel(128);
 
     let state = AppState {
         repository,
         broadcaster: tx,
+        rules: rule_engine,
     };
 
     let app = Router::new()
@@ -66,6 +70,39 @@ fn load_timeline_config() -> Result<CoreConfig, LogLineError> {
         .map_err(Into::into)
 }
 
+fn load_rule_engine_from_env() -> Result<Option<Arc<RuleEngine>>, RuleError> {
+    match std::env::var("TIMELINE_RULES_PATH") {
+        Ok(path) => {
+            let trimmed = path.trim();
+            if trimmed.is_empty() {
+                warn!("TIMELINE_RULES_PATH configured but empty; skipping rule engine");
+                return Ok(None);
+            }
+
+            let engine = RuleEngine::from_path(trimmed)?;
+            info!(
+                rule_count = engine.rules().len(),
+                %trimmed,
+                "loaded timeline rule definitions"
+            );
+            Ok(Some(Arc::new(engine)))
+        }
+        Err(std::env::VarError::NotPresent) => {
+            debug!(
+                "no TIMELINE_RULES_PATH configured; timeline will accept spans without rule enforcement"
+            );
+            Ok(None)
+        }
+        Err(err) => {
+            warn!(
+                ?err,
+                "failed to read TIMELINE_RULES_PATH, skipping rule loading"
+            );
+            Ok(None)
+        }
+    }
+}
+
 async fn health_check() -> &'static str {
     "ok"
 }
@@ -74,11 +111,16 @@ async fn health_check() -> &'static str {
 struct AppState {
     repository: TimelineRepository,
     broadcaster: broadcast::Sender<TimelineEntry>,
+    rules: Option<Arc<RuleEngine>>,
 }
 
 impl AppState {
     fn subscribe(&self) -> broadcast::Receiver<TimelineEntry> {
         self.broadcaster.subscribe()
+    }
+
+    fn rule_engine(&self) -> Option<&RuleEngine> {
+        self.rules.as_deref()
     }
 }
 
@@ -88,7 +130,43 @@ async fn create_span(
     State(state): State<AppState>,
     Json(payload): Json<CreateSpanRequest>,
 ) -> AppResult<Json<TimelineEntry>> {
-    let span = payload.into_span();
+    let mut span = payload.into_span();
+
+    if let Some(engine) = state.rule_engine() {
+        let outcome = engine.apply(&mut span);
+
+        if !outcome.applied_rules.is_empty() {
+            info!(
+                rules = ?outcome.applied_rules,
+                decision = ?outcome.decision,
+                "rules applied to incoming span"
+            );
+        }
+
+        match &outcome.decision {
+            Decision::Allow => {}
+            Decision::Reject { reason } => {
+                return Err(AppError::bad_request(reason.clone()));
+            }
+            Decision::Simulate { note } => {
+                span.status = SpanStatus::Simulated;
+                if let Some(note) = note {
+                    span.add_metadata("simulation_note", serde_json::Value::String(note.clone()));
+                }
+            }
+        }
+
+        if !outcome.applied_rules.is_empty() || !outcome.notes.is_empty() {
+            span.add_metadata(
+                "rule_engine",
+                serde_json::json!({
+                    "rules": outcome.applied_rules,
+                    "notes": outcome.notes,
+                }),
+            );
+        }
+    }
+
     let entry = state.repository.create_span(span).await?;
 
     if let Err(err) = state.broadcaster.send(entry.clone()) {
@@ -252,6 +330,8 @@ enum ServerError {
     Addr(#[from] std::net::AddrParseError),
     #[error("configuration error: {0}")]
     Config(#[from] LogLineError),
+    #[error("failed to load rule engine: {0}")]
+    Rules(#[from] RuleError),
     #[error("http server error: {0}")]
     Server(#[from] HyperError),
 }


### PR DESCRIPTION
## Summary
- add a dedicated `logline-rules` crate that encapsulates rule definitions, loading, and evaluation helpers
- wire the timeline service to optionally enforce rules before persisting spans and surface outcomes via metadata
- mark the roadmap task for the rules engine as started/done and include the crate in the workspace manifest

## Testing
- `cargo test` *(fails: repository currently has unresolved imports and missing types in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_b_68df07e2edc08328bb6060eb5fa9639c