### PR TITLE
Decouple engine from rules crate and harden gateway auth

### DIFF
--- a/RAILWAY_MANUAL_SETUP.md
+++ b/RAILWAY_MANUAL_SETUP.md
@@ -32,7 +32,7 @@ For each microservice:
 |--------------------|--------------------|----------------|-------|
 | `logline-id`       | `logline-id`       | `8079`         | Default health path `/health`
 | `logline-timeline` | `logline-timeline` | `8080`         | Requires Postgres URL (next step)
-| `logline-engine`   | `logline-engine`   | `8082`         | Set `ENGINE_RULES_PATH` env var if you ship rule files in the image/volume
+| `logline-engine`   | `logline-engine`   | `8082`         | Configure `RULES_URL` to point at the deployed `logline-rules` service |
 
 > ℹ️ Railway applies build args during image build. The default command matches `SERVICE`, so you only need to override `SERVICE_CMD` if you wrap the binary in a custom script.
 
@@ -46,7 +46,7 @@ TIMELINE_DATABASE_URL=${{Postgres.DATABASE_URL}}
 
 Optional variables:
 
-- `ENGINE_RULES_PATH` (engine service) – absolute path to a YAML/JSON rule bundle included in the image or mounted volume.
+- `ENGINE_RULES_URL` (engine service) – overrides the default `RULES_URL` when the engine must contact a private rules endpoint.
 - `TIMELINE_HTTP_BIND`, `ENGINE_HTTP_BIND`, etc., if you need to override the default bind addresses from code (defaults are already `0.0.0.0`).
 
 ## Step 5: Run Database Migrations
@@ -76,7 +76,7 @@ After completing the steps you will have:
 
 - ✅ PostgreSQL + three LogLine microservices running from the same Dockerfile
 - ✅ Timeline ledger isolated from rule execution
-- ✅ Engine service loading and applying rules locally when `ENGINE_RULES_PATH` is provided
+- ✅ Engine service delegating rule evaluation via HTTP when `RULES_URL` está configurado
 
 ## 📊 Service Architecture
 
@@ -96,7 +96,7 @@ After completing the steps you will have:
 
 - **Build failures**: confirm the correct `SERVICE` build arg, inspect Railway build logs for Cargo errors.
 - **Connection issues**: ensure `TIMELINE_DATABASE_URL` is present and migrations ran successfully.
-- **Rule evaluation**: verify the engine has access to the rule files referenced by `ENGINE_RULES_PATH`.
+- **Rule evaluation**: verify the engine can reach the rules endpoint defined by `RULES_URL`/`ENGINE_RULES_URL`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ Your local LogLine Universe is now fully operational.
     ```
 *   **Start Interacting**: Use the (forthcoming) LogLine CLI or build an application with the SDKs to start creating `spans` and building your own institutional memory.
 
+### Step 6: Iterate Quickly (Hot Reload & Hybrid Mode)
+
+*   **Container hot reload**: `docker compose watch logline-engine` ativa o sync automático de arquivos `.rs` para o container e recompila somente quando `Cargo.toml` muda.
+*   **Rodar nativamente com infra containerizada**: o script `scripts/dev-hybrid.sh` liga Postgres/Redis/rules/timeline via Docker e executa o serviço selecionado com `cargo run`.
+    ```bash
+    scripts/dev-hybrid.sh logline-engine
+    scripts/dev-hybrid.sh logline-timeline
+    ```
+    Ideal para usar o IDE local, `cargo watch` e outras ferramentas da linha de comando sem abrir mão do ecossistema já provisionado.
+
 ## 🎯 Use Cases: What You Can Build
 
 LogLine is not an application; it is a foundation. Here are a few examples of the systems you can build with it:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,126 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: logline
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: logline
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+  logline-rules:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE: logline-rules
+        SERVICE_PORT: 8081
+    environment:
+      RUST_LOG: info
+    depends_on:
+      - postgres
+    ports:
+      - "8081:8081"
+
+  logline-timeline:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE: logline-timeline
+        SERVICE_PORT: 8082
+    environment:
+      RUST_LOG: info
+      TIMELINE_DATABASE_URL: postgres://logline:password@postgres:5432/logline
+    depends_on:
+      - postgres
+    ports:
+      - "8082:8082"
+
+  logline-engine:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE: logline-engine
+        SERVICE_PORT: 8090
+    environment:
+      RUST_LOG: info
+      RULES_URL: http://logline-rules:8081
+      TIMELINE_WS_URL: ws://logline-timeline:8082/ws/service
+    depends_on:
+      - redis
+      - logline-rules
+      - logline-timeline
+    ports:
+      - "8090:8090"
+    develop:
+      watch:
+        - action: sync
+          path: ./logline-engine
+          target: /app/logline-engine
+        - action: rebuild
+          path: ./logline-engine/Cargo.toml
+
+  logline-gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE: logline-gateway
+        SERVICE_PORT: 8070
+    environment:
+      RUST_LOG: info
+      GATEWAY_BIND: 0.0.0.0:8070
+      ENGINE_URL: http://logline-engine:8090
+      RULES_URL: http://logline-rules:8081
+      TIMELINE_URL: http://logline-timeline:8082
+      ID_URL: http://logline-id:8083
+      FEDERATION_URL: http://logline-federation:8084
+      GATEWAY_JWT_SECRET: supersecret
+      GATEWAY_JWT_ISSUER: logline-id
+      GATEWAY_JWT_AUDIENCE: logline
+      GATEWAY_ALLOWED_ORIGINS: "*"
+      GATEWAY_PUBLIC_PATHS: /healthz
+    depends_on:
+      - logline-engine
+      - logline-rules
+      - logline-timeline
+    ports:
+      - "8070:8070"
+
+  logline-id:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE: logline-id
+        SERVICE_PORT: 8083
+    environment:
+      RUST_LOG: info
+    ports:
+      - "8083:8083"
+
+  logline-federation:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE: logline-federation
+        SERVICE_PORT: 8084
+    environment:
+      RUST_LOG: info
+    ports:
+      - "8084:8084"
+
+volumes:
+  pgdata:

--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -26,6 +26,7 @@ graph LR
         G1[REST Proxy]
         G2[WS Hub]
         G3[Health & Discovery]
+        G4[JWT Validator]
     end
 
     subgraph Services
@@ -38,6 +39,9 @@ graph LR
 
     A -->|/engine, /rules, ...| G1
     B -->|/ws| G2
+    A -. Bearer JWT .-> G4
+    B -. Bearer JWT .-> G4
+    G4 -->|context headers| G1
     G1 -->|HTTP| S1
     G1 -->|HTTP| S2
     G1 -->|HTTP| S3
@@ -48,6 +52,51 @@ graph LR
     G2 <-->|ServiceMessage WS| S3
     G3 -->|/healthz| Clients
 ```
+
+## Modelo de Segurança e Fronteira de Confiança
+
+O gateway é o **único** ponto do universo autorizado a validar tokens JWT. Todos
+os clientes externos apresentam o token no header `Authorization: Bearer ...` e
+o gateway executa as seguintes etapas:
+
+1. **Validação**: `jsonwebtoken` verifica assinatura, emissor, audiência e
+   expiração.
+2. **Decodificação**: o contexto autenticado (usuário, tenant, roles) é
+   armazenado na `AuthContext` interna.
+3. **Injeção de Contexto**: para cada chamada encaminhada aos microserviços, o
+   gateway acrescenta headers explícitos com a identidade autenticada.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Gateway
+    participant Engine as logline-engine
+
+    Client->>Gateway: Authorization: Bearer <JWT>
+    Gateway->>Gateway: Validar e decodificar JWT
+    Gateway->>Engine: X-User-ID, X-Tenant-ID, X-User-Roles
+    Engine->>Gateway: 200 OK
+    Gateway->>Client: 200 OK
+```
+
+### Headers propagados
+
+| Header          | Conteúdo                              |
+|-----------------|----------------------------------------|
+| `X-User-ID`     | Identificador do usuário autenticado   |
+| `X-Tenant-ID`   | Tenant atual (quando presente no token) |
+| `X-User-Roles`  | Lista de roles/escopos separados por espaço |
+| `X-Service-Token` | Token interno opcional para _service-to-service_ |
+
+### Modos de falha
+
+- **Token ausente ou inválido** → resposta `401 Unauthorized`.
+- **Audience/issuer incorretos** → `SecurityError::InvalidToken` registrado e
+  request descartada.
+- **Header inválido** → gateway registra `warn!` e descarta o header antes de
+  encaminhar (evita poison headers).
+- **Serviço interno fora do ar** → camadas de resiliência (`retry`, dead letter)
+  registram a falha sem expor dados sensíveis ao cliente.
 
 ## Exemplos de uso
 
@@ -61,7 +110,9 @@ curl -X POST \
 ```
 
 O gateway encaminha a requisição para `logline-rules`, preservando método, headers
-(Public/Host é reescrito) e corpo.
+(exceto `Host`/`Content-Length`) e corpo. O microserviço recebe os headers de
+contexto `X-User-ID`, `X-Tenant-ID` e `X-User-Roles`, não precisando lidar com
+JWTs diretamente.
 
 ### Hub WebSocket
 

--- a/logline-engine/Cargo.toml
+++ b/logline-engine/Cargo.toml
@@ -21,5 +21,5 @@ tracing = "0.1"
 uuid = { version = "1.6", features = ["serde", "v4"] }
 logline-core = { path = "../logline-core" }
 logline-protocol = { path = "../logline-protocol" }
-logline-rules = { path = "../logline-rules" }
+reqwest = { version = "0.11", features = ["json"] }
 url = "2.4"

--- a/logline-engine/src/api.rs
+++ b/logline-engine/src/api.rs
@@ -28,7 +28,7 @@ pub struct EngineServiceConfig {
     #[serde(default)]
     pub timeline_ws_url: Option<String>,
     #[serde(default)]
-    pub rules_path: Option<String>,
+    pub rules_service_url: Option<String>,
 }
 
 fn default_bind_address() -> String {
@@ -45,7 +45,7 @@ impl Default for EngineServiceConfig {
             bind_address: default_bind_address(),
             workers: default_worker_count(),
             timeline_ws_url: None,
-            rules_path: None,
+            rules_service_url: None,
         }
     }
 }

--- a/logline-engine/src/lib.rs
+++ b/logline-engine/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod api;
 pub mod error;
+pub mod rules_client;
 pub mod runtime;
 pub mod scheduler;
 pub mod task;
@@ -9,6 +10,7 @@ pub mod ws_client;
 
 pub use api::{EngineApiBuilder, EngineServiceConfig};
 pub use error::EngineError;
+pub use rules_client::{RulesClientError, RulesServiceClient};
 pub use runtime::{EngineHandle, ExecutionRuntime, TaskHandler};
 pub use scheduler::TaskScheduler;
 pub use task::{ExecutionOutcome, ExecutionTask, TaskPriority, TaskRecord, TaskStatus};

--- a/logline-engine/src/rules_client.rs
+++ b/logline-engine/src/rules_client.rs
@@ -1,0 +1,164 @@
+use std::fmt;
+
+use logline_protocol::timeline::Span;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use thiserror::Error;
+use url::Url;
+
+/// Typed HTTP client used by the engine to interact with the external
+/// `logline-rules` microservice.
+#[derive(Clone)]
+pub struct RulesServiceClient {
+    http: reqwest::Client,
+    base_url: Url,
+}
+
+impl RulesServiceClient {
+    /// Creates a new client bound to the provided base URL.
+    pub fn new(base_url: &str) -> Result<Self, RulesClientError> {
+        let mut url = Url::parse(base_url).map_err(|err| RulesClientError::InvalidUrl {
+            url: base_url.to_string(),
+            source: err,
+        })?;
+
+        if !url.path().ends_with('/') {
+            let mut path = url.path().trim_end_matches('/').to_string();
+            path.push('/');
+            url.set_path(&path);
+        }
+
+        Ok(Self {
+            http: reqwest::Client::new(),
+            base_url: url,
+        })
+    }
+
+    /// Sends the span for evaluation and returns the enriched outcome produced
+    /// by the rules service.
+    pub async fn evaluate_span(
+        &self,
+        tenant_id: &str,
+        span: &Span,
+    ) -> Result<RulesEvaluation, RulesClientError> {
+        let url = self
+            .base_url
+            .join(&format!(
+                "tenants/{}/evaluate",
+                encode_path_segment(tenant_id)
+            ))
+            .map_err(|err| RulesClientError::InvalidUrl {
+                url: format!("{}/tenants/{}/evaluate", self.base_url, tenant_id),
+                source: err,
+            })?;
+
+        let request = EvaluationRequest { span: span.clone() };
+
+        let response = self
+            .http
+            .post(url)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|err| RulesClientError::Http(err.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(RulesClientError::UnexpectedStatus {
+                status: response.status(),
+            });
+        }
+
+        let payload: EvaluationResponse = response
+            .json()
+            .await
+            .map_err(|err| RulesClientError::Decode(err.to_string()))?;
+
+        Ok(payload.into())
+    }
+
+    /// Returns the configured base URL as a string reference.
+    pub fn base_url(&self) -> &Url {
+        &self.base_url
+    }
+}
+
+fn encode_path_segment(segment: &str) -> String {
+    url::form_urlencoded::byte_serialize(segment.as_bytes()).collect()
+}
+
+#[derive(Debug, Serialize)]
+struct EvaluationRequest {
+    span: Span,
+}
+
+#[derive(Debug, Deserialize)]
+struct EvaluationResponse {
+    decision: EvaluationDecision,
+    applied_rules: Vec<String>,
+    notes: Vec<String>,
+    #[serde(default, rename = "tags")]
+    added_tags: Vec<String>,
+    #[serde(default)]
+    metadata_updates: Map<String, Value>,
+    span: Span,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct EvaluationDecision {
+    pub state: String,
+    #[serde(default)]
+    pub reason: Option<String>,
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
+impl fmt::Display for EvaluationDecision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(reason) = &self.reason {
+            write!(f, "{} ({})", self.state, reason)
+        } else if let Some(note) = &self.note {
+            write!(f, "{} ({})", self.state, note)
+        } else {
+            write!(f, "{}", self.state)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RulesEvaluation {
+    pub decision: EvaluationDecision,
+    pub applied_rules: Vec<String>,
+    pub notes: Vec<String>,
+    pub added_tags: Vec<String>,
+    pub metadata_updates: Map<String, Value>,
+    pub span: Span,
+}
+
+impl From<EvaluationResponse> for RulesEvaluation {
+    fn from(value: EvaluationResponse) -> Self {
+        Self {
+            decision: value.decision,
+            applied_rules: value.applied_rules,
+            notes: value.notes,
+            added_tags: value.added_tags,
+            metadata_updates: value.metadata_updates,
+            span: value.span,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum RulesClientError {
+    #[error("invalid rules service url {url}: {source}")]
+    InvalidUrl {
+        url: String,
+        #[source]
+        source: url::ParseError,
+    },
+    #[error("rules HTTP request failed: {0}")]
+    Http(String),
+    #[error("rules service returned unexpected status {status}")]
+    UnexpectedStatus { status: reqwest::StatusCode },
+    #[error("failed to decode rules response: {0}")]
+    Decode(String),
+}

--- a/logline-engine/src/ws_client.rs
+++ b/logline-engine/src/ws_client.rs
@@ -7,11 +7,11 @@ use logline_core::websocket::{
     ServiceMessageHandler, WebSocketPeer,
 };
 use logline_protocol::timeline::{Span, SpanStatus};
-use logline_rules::{Decision, RuleEngine};
-use serde_json::{json, Map, Value};
+use serde_json::{json, Value};
 use tracing::{debug, info, warn};
 use url::Url;
 
+use crate::rules_client::{RulesEvaluation, RulesServiceClient};
 use crate::runtime::EngineHandle;
 use crate::EngineServiceConfig;
 
@@ -19,7 +19,7 @@ const TIMELINE_PEER_NAME: &str = "logline-timeline";
 
 /// Initialise the engine WebSocket mesh connections based on the provided configuration.
 pub fn start_service_mesh(handle: EngineHandle, config: &EngineServiceConfig) {
-    let rules = load_rule_engine(config);
+    let rules = create_rules_client(config);
     let peers = collect_peers(config);
     if peers.is_empty() {
         info!("engine service mesh disabled: no peers configured");
@@ -69,40 +69,27 @@ fn peer_from_config(value: Option<&str>, name: &str) -> Option<WebSocketPeer> {
     })
 }
 
-fn load_rule_engine(config: &EngineServiceConfig) -> Option<Arc<RuleEngine>> {
+fn create_rules_client(config: &EngineServiceConfig) -> Option<Arc<RulesServiceClient>> {
     let candidate = config
-        .rules_path
+        .rules_service_url
         .as_deref()
         .map(str::to_owned)
-        .or_else(|| std::env::var("ENGINE_RULES_PATH").ok())
-        .or_else(|| std::env::var("RULES_PATH").ok());
+        .or_else(|| std::env::var("ENGINE_RULES_URL").ok())
+        .or_else(|| std::env::var("RULES_URL").ok());
 
     match candidate {
-        Some(path) => {
-            let trimmed = path.trim();
-            if trimmed.is_empty() {
-                warn!("rule engine path configured but empty; skipping local evaluation");
-                return None;
+        Some(url) => match RulesServiceClient::new(url.as_str()) {
+            Ok(client) => {
+                info!(rules_url = %client.base_url(), "configured remote rules service");
+                Some(Arc::new(client))
             }
-
-            match RuleEngine::from_path(trimmed) {
-                Ok(engine) => {
-                    let count = engine.rules().len();
-                    if count == 0 {
-                        warn!(%trimmed, "rule engine loaded with no rules");
-                    } else {
-                        info!(rule_count = count, %trimmed, "loaded local rule engine");
-                    }
-                    Some(Arc::new(engine))
-                }
-                Err(err) => {
-                    warn!(%trimmed, ?err, "failed to load local rule definitions");
-                    None
-                }
+            Err(err) => {
+                warn!(%url, ?err, "failed to initialise rules client; remote evaluation disabled");
+                None
             }
-        }
+        },
         None => {
-            debug!("no rule engine configuration provided; engine will skip local evaluation");
+            debug!("no rules service configured; engine will skip remote evaluation");
             None
         }
     }
@@ -110,14 +97,121 @@ fn load_rule_engine(config: &EngineServiceConfig) -> Option<Arc<RuleEngine>> {
 
 struct EngineMeshHandler {
     _handle: EngineHandle,
-    rules: Option<Arc<RuleEngine>>,
+    rules: Option<Arc<RulesServiceClient>>,
 }
 
 impl EngineMeshHandler {
-    fn new(handle: EngineHandle, rules: Option<Arc<RuleEngine>>) -> Self {
+    fn new(handle: EngineHandle, rules: Option<Arc<RulesServiceClient>>) -> Self {
         Self {
             _handle: handle,
             rules,
+        }
+    }
+
+    async fn dispatch_remote_rules(
+        &self,
+        client: &ServiceMeshClientHandle,
+        peer: &WebSocketPeer,
+        span_id: &str,
+        tenant_id: &str,
+        span: Span,
+        rules: &RulesServiceClient,
+    ) {
+        match rules.evaluate_span(tenant_id, &span).await {
+            Ok(outcome) => {
+                self.handle_rules_outcome(client, peer, span_id, tenant_id, outcome)
+                    .await;
+            }
+            Err(err) => {
+                warn!(
+                    peer = %peer.name,
+                    %span_id,
+                    %tenant_id,
+                    ?err,
+                    "remote rule evaluation failed"
+                );
+            }
+        }
+    }
+
+    async fn handle_rules_outcome(
+        &self,
+        client: &ServiceMeshClientHandle,
+        peer: &WebSocketPeer,
+        span_id: &str,
+        tenant_id: &str,
+        outcome: RulesEvaluation,
+    ) {
+        let RulesEvaluation {
+            decision,
+            applied_rules,
+            notes,
+            added_tags,
+            metadata_updates,
+            mut span,
+        } = outcome;
+
+        if decision.state == "simulate" {
+            span.status = SpanStatus::Simulated;
+            if let Some(note) = decision.note.as_ref() {
+                span.add_metadata("simulation_note", Value::String(note.clone()));
+            }
+        }
+
+        for tag in &added_tags {
+            span.add_tag(tag.clone());
+        }
+
+        if !applied_rules.is_empty() || !notes.is_empty() {
+            span.add_metadata(
+                "rule_engine",
+                json!({
+                    "rules": applied_rules.clone(),
+                    "notes": notes.clone(),
+                }),
+            );
+        }
+
+        for (key, value) in metadata_updates.iter() {
+            span.add_metadata(key.clone(), value.clone());
+        }
+
+        if let Some(reason) = decision.reason.as_ref() {
+            span.add_metadata("rule_decision_reason", Value::String(reason.clone()));
+        }
+
+        let metadata_value = Value::Object(metadata_updates.clone());
+        let decision_label = decision.state.clone();
+        let success = decision.state != "reject";
+        let output = json!({
+            "decision": decision_label,
+            "applied_rules": applied_rules,
+            "notes": notes,
+            "added_tags": added_tags,
+            "metadata_updates": metadata_value,
+            "span": span,
+        });
+
+        info!(
+            peer = %peer.name,
+            %span_id,
+            tenant = tenant_id,
+            decision = %decision,
+            "evaluated span via remote rules"
+        );
+
+        if let Err(err) = client
+            .send_to(
+                TIMELINE_PEER_NAME,
+                ServiceMessage::RuleExecutionResult {
+                    result_id: span_id.to_string(),
+                    success,
+                    output,
+                },
+            )
+            .await
+        {
+            warn!(%span_id, ?err, "failed to forward rule execution result to timeline");
         }
     }
 }
@@ -164,86 +258,46 @@ impl ServiceMessageHandler for EngineMeshHandler {
                     debug!(peer = %peer.name, %span_id, metadata = ?metadata, "span metadata received");
                 }
 
-                if tenant_id.is_none() {
-                    warn!(peer = %peer.name, %span_id, "span lacks tenant identifier; proceeding without tenant context");
-                }
+                let tenant = match tenant_id.as_deref() {
+                    Some(value) => value,
+                    None => {
+                        warn!(
+                            peer = %peer.name,
+                            %span_id,
+                            "span lacks tenant identifier; skipping remote rule evaluation"
+                        );
+                        return Ok(());
+                    }
+                };
 
-                if let Some(engine) = &self.rules {
+                if let Some(rules) = &self.rules {
                     match serde_json::from_value::<Span>(span.clone()) {
-                        Ok(mut parsed_span) => {
-                            let mut outcome = engine.apply(&mut parsed_span);
-                            let decision = outcome.decision.clone();
-
-                            if let Decision::Simulate { note } = &decision {
-                                parsed_span.status = SpanStatus::Simulated;
-                                if let Some(note) = note {
-                                    parsed_span.add_metadata(
-                                        "simulation_note",
-                                        Value::String(note.clone()),
-                                    );
-                                }
-                            }
-
-                            if !outcome.applied_rules.is_empty() || !outcome.notes.is_empty() {
-                                parsed_span.add_metadata(
-                                    "rule_engine",
-                                    json!({
-                                        "rules": outcome.applied_rules.clone(),
-                                        "notes": outcome.notes.clone(),
-                                    }),
-                                );
-                            }
-
-                            let mut metadata_updates = Map::new();
-                            for (key, value) in &outcome.metadata_updates {
-                                metadata_updates.insert(key.clone(), value.clone());
-                            }
-
-                            let decision_label = match &decision {
-                                Decision::Allow => "allow",
-                                Decision::Reject { .. } => "reject",
-                                Decision::Simulate { .. } => "simulate",
-                            };
-
-                            info!(
-                                peer = %peer.name,
-                                %span_id,
-                                tenant = tenant_id.as_deref().unwrap_or("unknown"),
-                                decision = decision_label,
-                                applied_rules = outcome.applied_rules.len(),
-                                "evaluated span locally"
-                            );
-
-                            let success = !matches!(decision, Decision::Reject { .. });
-                            let output = json!({
-                                "decision": decision_label,
-                                "applied_rules": outcome.applied_rules,
-                                "notes": outcome.notes,
-                                "added_tags": outcome.added_tags,
-                                "metadata_updates": metadata_updates,
-                                "span": parsed_span,
-                            });
-
-                            if let Err(err) = client
-                                .send_to(
-                                    TIMELINE_PEER_NAME,
-                                    ServiceMessage::RuleExecutionResult {
-                                        result_id: span_id.clone(),
-                                        success,
-                                        output,
-                                    },
-                                )
-                                .await
-                            {
-                                warn!(%span_id, ?err, "failed to forward rule execution result to timeline");
-                            }
+                        Ok(parsed_span) => {
+                            self.dispatch_remote_rules(
+                                &client,
+                                peer,
+                                &span_id,
+                                tenant,
+                                parsed_span,
+                                rules.as_ref(),
+                            )
+                            .await;
                         }
                         Err(err) => {
-                            warn!(peer = %peer.name, %span_id, ?err, "failed to decode span for evaluation");
+                            warn!(
+                                peer = %peer.name,
+                                %span_id,
+                                ?err,
+                                "failed to decode span for remote evaluation"
+                            );
                         }
                     }
                 } else {
-                    debug!(peer = %peer.name, %span_id, "no local rule engine configured; skipping evaluation");
+                    debug!(
+                        peer = %peer.name,
+                        %span_id,
+                        "no rules service configured; skipping remote evaluation"
+                    );
                 }
             }
             ServiceMessage::RuleExecutionResult {

--- a/scripts/dev-hybrid.sh
+++ b/scripts/dev-hybrid.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE="${1:-}" 
+
+if [[ -z "${SERVICE}" ]]; then
+  echo "Usage: scripts/dev-hybrid.sh <service>"
+  echo "Known services: logline-engine, logline-timeline"
+  exit 1
+fi
+
+# Start shared infrastructure in the background.
+docker compose up -d postgres redis logline-rules logline-timeline >/dev/null
+
+echo "Using local URLs:"
+echo "  Postgres: postgres://logline:password@localhost:5432/logline"
+echo "  Redis: redis://localhost:6379"
+
+export DATABASE_URL="postgres://logline:password@localhost:5432/logline"
+export TIMELINE_DATABASE_URL="${DATABASE_URL}"
+export REDIS_URL="redis://localhost:6379"
+export RULES_URL="http://127.0.0.1:8081"
+export TIMELINE_WS_URL="ws://127.0.0.1:8082/ws/service"
+
+case "${SERVICE}" in
+  logline-engine)
+    cargo run -p logline-engine
+    ;;
+  logline-timeline)
+    cargo run -p logline-timeline
+    ;;
+  *)
+    echo "Unknown service: ${SERVICE}" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- replace the engine's local logline-rules dependency with a typed HTTP client and remote evaluation flow
- update the rules service REST response, gateway security headers, and documentation to reflect the gateway-only JWT trust boundary
- add development ergonomics with a docker compose file, hot-reload watch config, and a hybrid dev shell script

## Testing
- `cargo fmt`
- `cargo check -p logline-engine`
- `cargo check -p logline-rules`


------
https://chatgpt.com/codex/tasks/task_b_68e03da7f0f88328ab131de148ad0cae