### PR TITLE
Atualiza gateway para compatibilidade com Axum 0.7

### DIFF
--- a/logline-gateway/Cargo.toml
+++ b/logline-gateway/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0"
-axum = { version = "0.7", features = ["macros", "ws"] }
+axum = { version = "0.7", features = ["macros", "ws", "http1"] }
 base64 = "0.21"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
@@ -19,9 +19,10 @@ reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.34", features = ["full"] }
-axum-server = { version = "0.5", features = ["rustls"] }
+axum-server = { version = "0.7", features = ["tls-rustls"] }
+axum-extra = { version = "0.9", features = ["typed-header"] }
 tokio-tungstenite = { version = "0.21", features = ["rustls-tls-native-roots"] }
-tower = { version = "0.4", features = ["timeout"] }
+tower = { version = "0.4", features = ["timeout", "limit", "make"] }
 tower-http = { version = "0.5", features = ["trace", "cors"] }
 tracing = "0.1"
 thiserror = "1.0"
@@ -34,9 +35,9 @@ http-body-util = "0.1"
 
 [dev-dependencies]
 serde_json = "1.0"
-axum = { version = "0.7", features = ["macros", "ws"] }
+axum = { version = "0.7", features = ["macros", "ws", "http1"] }
 tokio = { version = "1.34", features = ["full"] }
-axum-server = { version = "0.5", features = ["rustls"] }
+axum-server = { version = "0.7", features = ["tls-rustls"] }
 reqwest = { version = "0.11", features = ["json"] }
 tokio-tungstenite = { version = "0.21", features = ["rustls-tls-native-roots"] }
 anyhow = "1.0"

--- a/logline-gateway/src/lib.rs
+++ b/logline-gateway/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod discovery;
 pub mod health;
 pub mod onboarding;
+pub mod rate_limit;
 pub mod resilience;
 pub mod rest_routes;
 pub mod routing;

--- a/logline-gateway/src/rate_limit.rs
+++ b/logline-gateway/src/rate_limit.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::Response;
+use tracing::warn;
+
+#[derive(Debug)]
+struct RateWindow {
+    started_at: Instant,
+    count: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct RateLimitState {
+    limit: u64,
+    period: Duration,
+    window: Arc<Mutex<RateWindow>>,
+}
+
+impl RateLimitState {
+    pub fn new(limit: u64, period: Duration) -> Self {
+        let now = Instant::now();
+        Self {
+            limit,
+            period,
+            window: Arc::new(Mutex::new(RateWindow {
+                started_at: now,
+                count: 0,
+            })),
+        }
+    }
+
+    pub fn unlimited() -> Self {
+        Self::new(u64::MAX, Duration::from_secs(60))
+    }
+
+    pub fn try_acquire(&self) -> bool {
+        if self.limit == 0 {
+            return true;
+        }
+
+        let mut window = self.window.lock().expect("rate limit mutex poisoned");
+        let now = Instant::now();
+
+        if now.duration_since(window.started_at) >= self.period {
+            window.started_at = now;
+            window.count = 0;
+        }
+
+        if window.count < self.limit {
+            window.count += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+pub async fn enforce_rate_limit(
+    State(state): State<Arc<RateLimitState>>,
+    request: Request<Body>,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    if state.try_acquire() {
+        Ok(next.run(request).await)
+    } else {
+        warn!("taxa de requisições excedida");
+        Err(StatusCode::TOO_MANY_REQUESTS)
+    }
+}

--- a/logline-gateway/src/security.rs
+++ b/logline-gateway/src/security.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use axum::extract::State;
-use axum::http::{self, header, HeaderMap, HeaderValue, Method, StatusCode};
+use axum::body::Body;
+use axum::http::{self, header, HeaderMap, HeaderValue, Method, Request, StatusCode};
 use axum::middleware::Next;
 use axum::response::Response;
 use base64::Engine;
@@ -176,10 +177,10 @@ impl SecurityState {
     }
 }
 
-pub async fn enforce_auth<B>(
+pub async fn enforce_auth(
     State(state): State<Arc<SecurityState>>,
-    mut request: axum::http::Request<B>,
-    next: Next<B>,
+    mut request: Request<Body>,
+    next: Next,
 ) -> Result<Response, StatusCode> {
     let path = request.uri().path().to_string();
     let method = request.method().clone();

--- a/logline-gateway/src/ws_routes.rs
+++ b/logline-gateway/src/ws_routes.rs
@@ -4,13 +4,13 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
-use axum::headers::authorization::Bearer;
-use axum::headers::Authorization;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::Router;
-use axum::TypedHeader;
+use axum_extra::headers::authorization::Bearer;
+use axum_extra::headers::Authorization;
+use axum_extra::TypedHeader;
 use futures::{SinkExt, StreamExt};
 use logline_core::errors::LogLineError;
 use logline_core::websocket::{


### PR DESCRIPTION
## Summary
- habilita novas features de Axum e atualiza o axum-server para a série 0.7
- ajusta middlewares de autenticação, rate limit e timeout para as APIs do Axum 0.7
- cria módulo próprio de rate limit e atualiza o servidor principal para o novo fluxo de graceful shutdown

## Testing
- `cargo check -p logline-gateway`


------
https://chatgpt.com/codex/tasks/task_b_68e14929af7083289700c249059df524