### PR TITLE
Add deployment and cleanup planning documentation

### DIFF
--- a/docs/logline-deployment-cleanup-protocol.md
+++ b/docs/logline-deployment-cleanup-protocol.md
@@ -1,0 +1,111 @@
+# LogLine Deployment Cleanup Protocol
+
+## Post-Deployment Sanitization
+
+### 1. Temporary File Inventory
+
+Locations to clean:
+
+```bash
+# Diagnostic artifacts
+/tmp/logline-*.log
+
+# Build artifacts
+/Users/voulezvous/Downloads/logline_id_unificado/target/
+~/.cargo/registry/
+
+# Old configurations
+~/.config/logline/session.toml.old
+/usr/local/etc/logline/config.toml.bak
+```
+
+### 2. Automated Cleanup Script
+
+```bash
+#!/usr/bin/env bash
+# save as: scripts/cleanup-logline.sh
+
+echo "🌀 LogLine Cleanup Utility"
+
+# 1. Log Files
+echo "🧹 Cleaning log files..."
+find /tmp -name "logline-*.log" -mtime +7 -delete
+
+# 2. Build Artifacts
+echo "🛠️  Cleaning build artifacts..."
+(cd /Users/voulezvous/Downloads/logline_id_unificado && cargo clean)
+
+# 3. Configuration Versions
+echo "⚙️  Pruning old configs:"
+find ~/.config/logline/ -name "*.old" -delete
+find /usr/local/etc/logline/ -name "*.bak" -delete
+
+# 4. Service Reset
+echo "♻️  Resetting service:"
+sudo launchctl unload /Library/LaunchDaemons/com.danvoulez.logline.plist 2>/dev/null
+sudo rm -f /Library/LaunchDaemons/com.danvoulez.logline.plist
+
+echo "✅ Cleanup complete"
+```
+
+### 3. Scheduled Maintenance
+
+Add to crontab (runs weekly):
+
+```bash
+(crontab -l 2>/dev/null; echo "0 3 * * 0 /Users/voulezvous/Downloads/logline_id_unificado/scripts/cleanup-logline.sh") | crontab -
+```
+
+### 4. Verification Checks
+
+```bash
+# Post-cleanup validation
+du -sh /tmp/logline-*  # Should show 0B
+cargo metadata --format-version 1 | jq '.target_directory' # Verify clean build
+```
+
+### 5. Safe File Retention
+
+Preserve these critical files:
+
+- /usr/local/bin/logline
+- /usr/local/etc/logline/config.toml
+- /Library/LaunchDaemons/com.danvoulez.logline.plist
+- ~/.config/logline/session.toml
+
+## Cleanup Safety Protocol
+
+### Dry Run First
+
+```bash
+./scripts/cleanup-logline.sh --dry-run
+```
+
+### Confirmation Prompt
+
+Add to script:
+
+```bash
+read -p "Delete 7+ day old logs? (y/n): " confirm
+[[ $confirm == [yY] ]] || exit
+```
+
+## Post-Cleanup Checklist
+
+Verify service restarts:
+
+```bash
+sudo launchctl load /Library/LaunchDaemons/com.danvoulez.logline.plist
+```
+
+Confirm API availability:
+
+```bash
+curl -sI http://100.102.181.95:8070/health | head -1
+```
+
+Check Tailscale peers:
+
+```bash
+tailscale status | grep -E "(active)"
+```

--- a/docs/logline-federation-node-deployment-master-plan.md
+++ b/docs/logline-federation-node-deployment-master-plan.md
@@ -1,0 +1,125 @@
+# LogLine Federation Node Deployment Master Plan
+
+## Current Obstacles
+
+### Code Issues
+- Missing critical Rust imports (Arc, Router, etc.)
+- Incomplete error handling
+- No explicit Tailscale IP binding
+
+### Service Management
+- Launchd configuration errors
+- No persistence across reboots
+- Missing log rotation
+
+### Network Configuration
+- Port 8070 not properly exposed
+- Firewall restrictions
+- Tailscale peer verification needed
+
+## Required Phases
+
+### 1. Codebase Remediation
+```rust
+// src/main.rs critical fixes:
+use std::sync::Arc;
+use axum::{Router, Extension};
+use axum::routing::{get, post};
+use tower_http::trace::TraceLayer;
+
+// Add to Cargo.toml:
+[dependencies]
+tower-http = { version = "0.5", features = ["trace"] }
+```
+
+### 2. Build & Deployment
+```bash
+# Clean rebuild
+cargo build --release --bin logline
+
+# Install
+sudo install -m 0755 target/release/logline /usr/local/bin/
+
+# Configuration
+mkdir -p /usr/local/etc/logline
+cat > /usr/local/etc/logline/config.toml <<'CONFIG'
+[network]
+tailscale_ip = "100.102.181.95"
+federation_peers = ["100.72.6.121"]
+CONFIG
+```
+
+### 3. Service Orchestration
+```bash
+# Systemd-style service (macOS launchd alternative)
+sudo tee /Library/LaunchDaemons/com.danvoulez.logline.plist <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.danvoulez.logline</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/logline</string>
+        <string>--config</string>
+        <string>/usr/local/etc/logline/config.toml</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+</dict>
+</plist>
+PLIST
+
+# Activate
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.danvoulez.logline.plist
+```
+
+### 4. Network Finalization
+```bash
+# Tailscale
+sudo tailscale up --advertise-exit-node --accept-routes
+
+# Firewall
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/local/bin/logline
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/local/bin/logline
+```
+
+### 5. Verification Matrix
+
+| Check | Command | Expected Output |
+| --- | --- | --- |
+| Service Status | `sudo launchctl list | grep logline` | Process entry present |
+| API Health | `curl -s http://100.102.181.95:8070/health` | HTTP 200 OK |
+| Tailscale | `tailscale status | grep macmini` | `100.102.181.95 active` |
+| Logs | `tail /usr/local/var/log/logline.log` | No `ERROR` entries |
+
+## Timeline
+
+### Immediate (5 mins)
+- Fix code imports
+- Manual test run
+
+### Phase 1 (15 mins)
+- Implement config file
+- Basic service install
+
+### Phase 2 (30 mins)
+- Full persistence setup
+- Network hardening
+
+### Phase 3 (Ongoing)
+- Monitoring integration
+- Peer synchronization
+
+## Risk Mitigation
+
+### Fallback Plan
+```bash
+# Emergency start script
+nohup /usr/local/bin/logline run --gateway http://100.102.181.95:8070 > /tmp/logline-fallback.log 2>&1 &
+```
+
+Would you like me to proceed with any specific phase or modify the approach? This provides the complete roadmap to production-grade deployment.


### PR DESCRIPTION
## Summary
- add the federation node deployment master plan covering remediation, deployment, orchestration, networking, and verification steps
- add the deployment cleanup protocol detailing post-deployment sanitization, automation, scheduling, and safety checks

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_b_68e17c0b6eac8328b9a85a26bc9a07ac